### PR TITLE
Moved AWS Wrangler back into the write_pandas_df method for now.

### DIFF
--- a/spp/engine/write.py
+++ b/spp/engine/write.py
@@ -1,5 +1,3 @@
-import awswrangler as wr
-
 current_module = "SPP Engine - Write"
 
 
@@ -34,6 +32,7 @@ def pandas_write(df, data_target, logger, **kwargs):
 
 
 def write_pandas_df_to_s3(df, data_target, logger):
+    import awswrangler as wr
 
     logger.debug(f"Pandas write data target {repr(data_target)}")
 


### PR DESCRIPTION
AWS Wrangler is needed for the pandas write and was imported directly within the method. We wanted to move this out to import the dependency properly but this failed as we don't have AWS Wrangler available. This is to move it back into the method for now and a tech debt ticket SPP-1508 has been raised to cover this work.